### PR TITLE
Gemfile atualizado devido à vulnerabilidade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.9'
+gem 'rails', '3.2.11'
 
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'


### PR DESCRIPTION
Atualizei o Gemfile e setei a gem rails para a versão '3.2.11' que está sendo indicado devido à vulnerabilidade descoberta.
